### PR TITLE
US625210: Initialize NSS for containers to run on host in FIPS mode

### DIFF
--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -29,13 +29,7 @@ ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-s
     /startup/startup.d/
 RUN chmod +x /startup/startup.d/install-ca-cert-java.sh
 
-
-# Installing CA Certificate on openSUSE:
-# cp -v /test-keystore/test-cert.csr /etc/pki/trust/anchors/test-cert.csr.crt
-# Importing CA cert into Java Keystore on openSUSE:
-# keytool -noprompt -keystore /usr/lib64/jvm/jre/lib/security/cacerts -storepass changeit -importcert -alias caf-ssl-ca-cert-0 -file /test-keystore/test-cert.csr
-
-RUN echo "Removing cert install scripts..." && rm /startup/startup.d/install*cert*.sh
+# RUN echo "Removing cert install scripts..." && rm /startup/startup.d/install*cert*.sh
 
 # Add in the startup scripts
 COPY startup.d/ /startup/startup.d/

--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -29,12 +29,9 @@ ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-s
     /startup/startup.d/
 RUN chmod +x /startup/startup.d/install-ca-cert-java.sh
 
-# RUN echo "Removing cert install scripts..." && rm /startup/startup.d/install*cert*.sh
-
-# Add in the startup scripts
+# Add the startup scripts
 COPY startup.d/ /startup/startup.d/
 RUN chmod +x /startup/startup.d/*
-
 
 # Set JRE Home
 ENV JRE_HOME=/usr/lib64/jvm/java-17-openjdk-17

--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -38,8 +38,8 @@ RUN chmod +x /startup/startup.d/install-ca-cert-java.sh
 RUN echo "Removing cert install scripts..." && rm /startup/startup.d/install*cert*.sh
 
 # Add in the startup scripts
-COPY startup.d/ root/startup/startup.d/
-RUN chmod +x root/startup/startup.d/*
+COPY startup.d/ /startup/startup.d/
+RUN chmod +x /startup/startup.d/*
 
 
 # Set JRE Home

--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -21,13 +21,26 @@ FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-base:2
 # Refresh the OS repositories and install OpenJDK 17 Runtime Environment
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install java-17-openjdk && \
+    zypper -n install java-17-openjdk mozilla-nss-tools && \
     zypper -n clean --all
 
 # Install Java certificate installation script
 ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-script/install-ca-cert-java.sh \
     /startup/startup.d/
 RUN chmod +x /startup/startup.d/install-ca-cert-java.sh
+
+
+# Installing CA Certificate on openSUSE:
+# cp -v /test-keystore/test-cert.csr /etc/pki/trust/anchors/test-cert.csr.crt
+# Importing CA cert into Java Keystore on openSUSE:
+# keytool -noprompt -keystore /usr/lib64/jvm/jre/lib/security/cacerts -storepass changeit -importcert -alias caf-ssl-ca-cert-0 -file /test-keystore/test-cert.csr
+
+RUN echo "Removing cert install scripts..." && rm /startup/startup.d/install*cert*.sh
+
+# Add in the startup scripts
+COPY startup.d/ root/startup/startup.d/
+RUN chmod +x root/startup/startup.d/*
+
 
 # Set JRE Home
 ENV JRE_HOME=/usr/lib64/jvm/java-17-openjdk-17

--- a/src/main/docker/startup.d/initialize-nssdb.sh
+++ b/src/main/docker/startup.d/initialize-nssdb.sh
@@ -15,14 +15,8 @@
 # limitations under the License.
 #
 
-
-MESOS_SANDBOX=${SSL_CA_CRT_DIR:-$MESOS_SANDBOX}
-
 echo "Make /etc/pki/nssdb..."
 mkdir /etc/pki/nssdb
 
-echo "init nssdb..."
+echo "Initialize nssdb..."
 certutil -N --empty-password -d /etc/pki/nssdb/
-
-# echo "Adding CA cert into NSS database on openSUSE"
-# certutil -A -n test-cert -t "u,u,u" -d /etc/pki/nssdb/ -i $MESOS_SANDBOX/$SSL_CA_CRT

--- a/src/main/docker/startup.d/install-ca-cert-nss.sh
+++ b/src/main/docker/startup.d/install-ca-cert-nss.sh
@@ -27,5 +27,5 @@ certutil -N --empty-password -d /etc/pki/nssdb/
 echo "Contents of cert folder..."
 ls -l $MESOS_SANDBOX/$SSL_CA_CRT
 
-echo "Adding CA cert into NSS database on openSUSE"
-certutil -A -n test-cert -t "u,u,u" -d /etc/pki/nssdb/ -i $MESOS_SANDBOX/$SSL_CA_CRT
+# echo "Adding CA cert into NSS database on openSUSE"
+# certutil -A -n test-cert -t "u,u,u" -d /etc/pki/nssdb/ -i $MESOS_SANDBOX/$SSL_CA_CRT

--- a/src/main/docker/startup.d/install-ca-cert-nss.sh
+++ b/src/main/docker/startup.d/install-ca-cert-nss.sh
@@ -24,8 +24,5 @@ mkdir /etc/pki/nssdb
 echo "init nssdb..."
 certutil -N --empty-password -d /etc/pki/nssdb/
 
-echo "Contents of cert folder..."
-ls -l $MESOS_SANDBOX/$SSL_CA_CRT
-
 # echo "Adding CA cert into NSS database on openSUSE"
 # certutil -A -n test-cert -t "u,u,u" -d /etc/pki/nssdb/ -i $MESOS_SANDBOX/$SSL_CA_CRT

--- a/src/main/docker/startup.d/install-ca-cert-nss.sh
+++ b/src/main/docker/startup.d/install-ca-cert-nss.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright 2022-2023 Open Text.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+MESOS_SANDBOX=${SSL_CA_CRT_DIR:-$MESOS_SANDBOX}
+
+echo "Make /etc/pki/nssdb..."
+mkdir /etc/pki/nssdb
+
+echo "init nssdb..."
+certutil -N -d /etc/pki/nssdb/
+
+echo "Adding CA cert into NSS database on openSUSE"
+certutil -A -n test-cert -t “u,u,u” -d /etc/pki/nssdb/ -i $MESOS_SANDBOX/$SSL_CA_CRT

--- a/src/main/docker/startup.d/install-ca-cert-nss.sh
+++ b/src/main/docker/startup.d/install-ca-cert-nss.sh
@@ -22,7 +22,10 @@ echo "Make /etc/pki/nssdb..."
 mkdir /etc/pki/nssdb
 
 echo "init nssdb..."
-certutil -N -d /etc/pki/nssdb/
+certutil -N --empty-password -d /etc/pki/nssdb/
+
+echo "Contents of cert folder..."
+ls -l $MESOS_SANDBOX/$SSL_CA_CRT
 
 echo "Adding CA cert into NSS database on openSUSE"
-certutil -A -n test-cert -t “u,u,u” -d /etc/pki/nssdb/ -i $MESOS_SANDBOX/$SSL_CA_CRT
+certutil -A -n test-cert -t "u,u,u" -d /etc/pki/nssdb/ -i $MESOS_SANDBOX/$SSL_CA_CRT


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=625210