### PR TITLE
I907068: Allow write access to NSS db to non-root users

### DIFF
--- a/release-notes-1.5.1.md
+++ b/release-notes-1.5.1.md
@@ -7,8 +7,5 @@ ${version-number}
 #### Bug Fixes
 - I907068: Fixed issue with non-root users being unable to write to NSS directory.
 
-#### Patch Fixes Included
-- This release includes OS package updates only.
-
 #### Known Issues
 - None

--- a/release-notes-1.5.1.md
+++ b/release-notes-1.5.1.md
@@ -4,6 +4,9 @@ ${version-number}
 #### New Features
 - None
 
+#### Bug Fixes
+I907068: Fixed issue with non-root users being unable to write to NSS directory.
+
 #### Patch Fixes Included
 - This release includes OS package updates only.
 

--- a/release-notes-1.5.1.md
+++ b/release-notes-1.5.1.md
@@ -5,7 +5,7 @@ ${version-number}
 - None
 
 #### Bug Fixes
-I907068: Fixed issue with non-root users being unable to write to NSS directory.
+- I907068: Fixed issue with non-root users being unable to write to NSS directory.
 
 #### Patch Fixes Included
 - This release includes OS package updates only.

--- a/release-notes-1.5.1.md
+++ b/release-notes-1.5.1.md
@@ -5,7 +5,7 @@ ${version-number}
 - None
 
 #### Bug Fixes
-- I907068: Fixed issue with non-root users being unable to write to NSS directory.
+- I907068: Fixed issue with non-root users being unable to write to the NSS directory.
 
 #### Known Issues
 - None

--- a/src/main/docker/Dockerfile.jdk
+++ b/src/main/docker/Dockerfile.jdk
@@ -48,7 +48,7 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', and because the OpenSearch service run as a non-root user, we need to adjust permissions accordingly.
+# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
 # See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
 RUN chmod a+rw /etc/pki/nssdb/*
 

--- a/src/main/docker/Dockerfile.jdk
+++ b/src/main/docker/Dockerfile.jdk
@@ -48,7 +48,9 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-RUN chmod +r /etc/pki/nssdb/*
+# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', and because the OpenSearch service run as a non-root user, we need to adjust permissions accordingly.
+# See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
+RUN chmod a+rw /etc/pki/nssdb/*
 
 #
 # Stage 3: The remainder of the actual image definition

--- a/src/main/docker/Dockerfile.jdk
+++ b/src/main/docker/Dockerfile.jdk
@@ -48,7 +48,7 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
+# The '/etc/pkii/nssdb/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
 # See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
 RUN chmod a+rw /etc/pki/nssdb/*
 

--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -45,7 +45,7 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', and because the OpenSearch service run as a non-root user, we need to adjust permissions accordingly.
+# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
 # See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
 RUN chmod a+rw /etc/pki/nssdb/*
 

--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -45,7 +45,7 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
+# The '/etc/pkii/nssdb/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
 # See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
 RUN chmod a+rw /etc/pki/nssdb/*
 

--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -45,7 +45,9 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-RUN chmod +r /etc/pki/nssdb/*
+# In '/etc/pkii/nssdb/nss.fips.cfg' we have 'nssDbMode=readWrite', and because the OpenSearch service run as a non-root user, we need to adjust permissions accordingly.
+# See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
+RUN chmod a+rw /etc/pki/nssdb/*
 
 #
 # Stage 3: The remainder of the actual image definition


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=907068

Prior to a recent Java update, the `/usr/lib64/jvm/java-17-openjdk-17/conf/security/nss.fips.cfg` file had the following property:

```
nssDbMode=readOnly
```

and the `/etc/pki/nssdb` dir has the following perms:

```
drwxr-xr-x. 1 root root    37 Mar  8 13:35 .
drwxr-xr-x. 1 root root    32 Apr  8 08:40 ..
-rw-r--r--. 1 root root 28672 Mar  8 13:35 cert9.db
-rw-r--r--. 1 root root 36864 Mar  8 13:35 key4.db
-rw-r--r--. 1 root root   421 Mar  8 13:35 pkcs11.txt
```

However, in newer versions of Java (such as `build 17.0.10+7-suse-150400.3.39.2-x8664`), this has changed to:

```
nssDbMode=readWrite
```

which means services running as non-root can no longer access the NSS db, so I have changed the permissions to:

```
drwxr-xr-x. 1 root root    55 Mar  8 13:35 .
drwxr-xr-x. 1 root root    32 Apr  8 08:40 ..
-rw-rw-rw-. 1 root root 28672 Mar  8 13:35 cert9.db
-rw-rw-rw-. 1 root root 36864 Mar  8 13:35 key4.db
-rw-rw-rw-. 1 root root   421 Mar  8 13:35 pkcs11.txt
```