### PR TITLE
I907068: Fix typos in comments

### DIFF
--- a/src/main/docker/Dockerfile.jdk
+++ b/src/main/docker/Dockerfile.jdk
@@ -48,7 +48,7 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-# The '/etc/pkii/nssdb/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
+# The '/usr/lib64/jvm/java-17-openjdk-17/conf/security/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
 # See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
 RUN chmod a+rw /etc/pki/nssdb/*
 

--- a/src/main/docker/Dockerfile.jre
+++ b/src/main/docker/Dockerfile.jre
@@ -45,7 +45,7 @@ RUN zypper -n install mozilla-nss-tools
 
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
-# The '/etc/pkii/nssdb/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
+# The '/usr/lib64/jvm/java-17-openjdk-17/conf/security/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
 # See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
 RUN chmod a+rw /etc/pki/nssdb/*
 


### PR DESCRIPTION
Fix typos in previous commit: https://github.com/CAFapi/opensuse-java17-images/commit/c7c8f22c330e90a34b74ef800152f4fcdca8e741